### PR TITLE
fix / MainButton 이벤트 리스너 및 추가 프로퍼티 개선

### DIFF
--- a/src/components/atoms/buttons/MainButton.tsx
+++ b/src/components/atoms/buttons/MainButton.tsx
@@ -3,18 +3,22 @@ import { SerializedStyles, css } from '@emotion/react';
 type Type = 'filled' | 'outline';
 
 interface IMainButtonProps {
-  type: Type;
+  type?: Type;
   disabled?: boolean;
   children: React.ReactNode;
+  css?: SerializedStyles;
+  onClick: () => void;
 }
 
 const styles: { [key in Type]: SerializedStyles } = {
   filled: css`
     background: var(--main-red-500);
     color: var(--grey-0);
+
     &:hover:enabled {
       filter: brightness(90%);
     }
+
     &:disabled {
       background: var(--grey-300);
     }
@@ -23,9 +27,11 @@ const styles: { [key in Type]: SerializedStyles } = {
     background: transparent;
     border: 1px solid var(--main-red-500);
     color: var(--main-red-500);
+
     &:hover:enabled {
       background: #f151391a;
     }
+
     &:disabled {
       color: var(--grey-400);
       border: 1px solid var(--grey-200);
@@ -33,11 +39,13 @@ const styles: { [key in Type]: SerializedStyles } = {
   `,
 };
 
-export default function MainButton({
-  type = 'filled',
-  disabled = false,
-  children,
-}: IMainButtonProps) {
+export default function MainButton(
+  {
+    type = 'filled',
+    disabled = false,
+    children,
+    onClick,
+  }: IMainButtonProps) {
   return (
     <button
       disabled={disabled}
@@ -55,6 +63,7 @@ export default function MainButton({
         `,
         styles[type],
       )}
+      onClick={onClick}
     >
       {children}
     </button>


### PR DESCRIPTION
### 변경된 점

- MainButton.tsx css props 추가
  - 넓이가 컴포넌트와 다른 경우가 존재합니다 (ex. profile-setting -> profile-intro filled 버튼)
- onClick props 추가
  -  onClick 핸들러가 필요한데 없어서 추가 했습니다.